### PR TITLE
Add dll path for windows in launch config json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "cwd": "${workspaceRoot}/RogueCastle/bin/x64/Debug/net40/",
             "linux": {
                 "env": {
-                    "LD_LIBRARY_PATH": "${workspaceRoot}/fnalibs3/x64/"
+                    "LD_LIBRARY_PATH": "${workspaceRoot}/fnalibs3/lib64/"
                 }
             },
             "windows": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,16 @@
             "request": "launch",
             "program": "${workspaceRoot}/RogueCastle/bin/x64/Debug/net40/RogueLegacy.exe",
             "cwd": "${workspaceRoot}/RogueCastle/bin/x64/Debug/net40/",
-            "env": {
-                "LD_LIBRARY_PATH": "${workspaceRoot}/fnalibs3/lib64/"
-            }
+            "linux": {
+                "env": {
+                    "LD_LIBRARY_PATH": "${workspaceRoot}/fnalibs3/x64/"
+                }
+            },
+            "windows": {
+                "env": {
+                    "PATH": "${workspaceRoot}/fnalibs3/x64/;${env:PATH}"
+                }
+            },
         },
         {
             "name": "Attach",


### PR DESCRIPTION
## Changes:
For easier setup in Windows environments, include an env variable for `PATH` rather than `LD_LIBRARY_PATH` which seems to be specific to Linux.


## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial release of Rogue Legacy
- [x] I will be credited in a `CONTRIBUTORS` file and the "GitHub Friends"
  section of the credits for all of said releases, but will NOT be compensated
  for these changes unless there is a prior written agreement
